### PR TITLE
Add multi-frame processing entry points

### DIFF
--- a/va/va.c
+++ b/va/va.c
@@ -401,6 +401,9 @@ static VAStatus va_openDriver(VADisplay dpy, char *driver_name)
                     CHECK_VTABLE(vaStatus, ctx, DestroySurfaces);
                     CHECK_VTABLE(vaStatus, ctx, CreateContext);
                     CHECK_VTABLE(vaStatus, ctx, DestroyContext);
+                    CHECK_VTABLE(vaStatus, ctx, CreateMFContext);
+                    CHECK_VTABLE(vaStatus, ctx, MFAddContext);
+                    CHECK_VTABLE(vaStatus, ctx, MFReleaseContext);
                     CHECK_VTABLE(vaStatus, ctx, CreateBuffer);
                     CHECK_VTABLE(vaStatus, ctx, BufferSetNumElements);
                     CHECK_VTABLE(vaStatus, ctx, MapBuffer);
@@ -409,6 +412,7 @@ static VAStatus va_openDriver(VADisplay dpy, char *driver_name)
                     CHECK_VTABLE(vaStatus, ctx, BeginPicture);
                     CHECK_VTABLE(vaStatus, ctx, RenderPicture);
                     CHECK_VTABLE(vaStatus, ctx, EndPicture);
+                    CHECK_VTABLE(vaStatus, ctx, MFSubmit);
                     CHECK_VTABLE(vaStatus, ctx, SyncSurface);
                     CHECK_VTABLE(vaStatus, ctx, QuerySurfaceStatus);
                     CHECK_VTABLE(vaStatus, ctx, PutSurface);
@@ -1119,6 +1123,78 @@ VAStatus vaDestroyContext (
   VA_TRACE_ALL(va_TraceDestroyContext, dpy, context);
 
   return vaStatus;
+}
+
+VAStatus vaCreateMFContext (
+    VADisplay dpy,
+    VAMFContextID *mf_context    /* out */
+)
+{
+    VADriverContextP ctx;
+    VAStatus vaStatus;
+
+    CHECK_DISPLAY(dpy);
+    ctx = CTX(dpy);
+
+    vaStatus = ctx->vtable->vaCreateMFContext( ctx, mf_context);
+    VA_TRACE_ALL(va_TraceCreateMFContext, dpy, mf_context);
+
+    return vaStatus;
+}
+
+VAStatus vaMFAddContext (
+    VADisplay dpy,
+    VAContextID context,
+    VAMFContextID mf_context
+)
+{
+    VADriverContextP ctx;
+    VAStatus vaStatus;
+
+    CHECK_DISPLAY(dpy);
+    ctx = CTX(dpy);
+
+    vaStatus = ctx->vtable->vaMFAddContext( ctx, context, mf_context);
+    VA_TRACE_ALL(va_TraceMFAddContext, dpy, context, mf_context);
+
+    return vaStatus;
+}
+
+VAStatus vaMFReleaseContext (
+    VADisplay dpy,
+    VAContextID context,
+    VAMFContextID mf_context
+)
+{
+    VADriverContextP ctx;
+    VAStatus vaStatus;
+
+    CHECK_DISPLAY(dpy);
+    ctx = CTX(dpy);
+
+    vaStatus = ctx->vtable->vaMFReleaseContext( ctx, context, mf_context);
+    VA_TRACE_ALL(va_TraceMFReleaseContext, dpy, context, mf_context);
+
+    return vaStatus;
+}
+
+VAStatus vaMFSubmit (
+    VADisplay dpy,
+    VAMFContextID mf_context,
+    VAContextID *contexts,
+    int num_contexts
+)
+{
+    VADriverContextP ctx;
+    VAStatus vaStatus;
+
+    CHECK_DISPLAY(dpy);
+    ctx = CTX(dpy);
+
+    vaStatus = ctx->vtable->vaMFSubmit( ctx, mf_context, contexts, num_contexts);
+    VA_TRACE_ALL(va_TraceMFSubmit, dpy, mf_context, contexts, num_contexts);
+
+    return vaStatus;
 }
 
 VAStatus vaCreateBuffer (

--- a/va/va.h
+++ b/va/va.h
@@ -1154,7 +1154,11 @@ VAStatus vaCreateMFContext (
  *  context: VAContextID to be added
  *  mf_context: VAMFContextID where context is added
  */
-VAStatus vaMFAddContext (VADisplay dpy, VAContextID context, VAMFContextID mfe_context)
+VAStatus vaMFAddContext (
+    VADisplay dpy,
+    VAContextID context,
+    VAMFContextID mfe_context
+);
 
 /**
  * vaMFReleaseContext - Removes context from multi-frame and
@@ -1164,7 +1168,11 @@ VAStatus vaMFAddContext (VADisplay dpy, VAContextID context, VAMFContextID mfe_c
  *  context: VAContextID to be added
  *  mf_context: VAMFContextID where context is added
  */
-VAStatus vaMFReleaseContext (VADisplay dpy, VAContextID context, VAMFContextID mfe_context)
+VAStatus vaMFReleaseContext (
+    VADisplay dpy,
+    VAContextID context,
+    VAMFContextID mfe_context
+);
 
 /**
  * Buffers 

--- a/va/va.h
+++ b/va/va.h
@@ -1119,7 +1119,7 @@ VAStatus vaCreateContext (
     int num_render_targets,
     VAContextID *context		/* out */
 );
-	
+
 /**
  * vaDestroyContext - Destroy a context 
  *  dpy: display
@@ -1136,7 +1136,7 @@ typedef VAGenericID VAMFContextID;
  * vaCreateMFContext - Create a multi-frame context
  *  Multi-frame context allow to run tasks from different
  *  contexts in single batch buffer for performance optimization.
- *  Multi-frame context destroyd by vaDestroyContext
+ *  Multi-frame context is destroyed through vaDestroyContext
  *  dpy: display
  *  mf_context: created multi-frame context id upon return
  */
@@ -2541,7 +2541,7 @@ VAStatus vaEndPicture (
 /**
  * Make the end of rendering for a pictures in contexts passed with submission. 
  * The server should start processing all pending operations for contexts.
- * All contexts passed to should be associated through vaMFAddContext
+ * All contexts passed should be associated through vaMFAddContext
  * and call sequence Begin/Render/End performed.
  * This call is non-blocking. The client can start another 
  * Begin/Render/End/vaMFSubmit sequence on a different render targets.

--- a/va/va.h
+++ b/va/va.h
@@ -1119,7 +1119,7 @@ VAStatus vaCreateContext (
     int num_render_targets,
     VAContextID *context		/* out */
 );
-
+	
 /**
  * vaDestroyContext - Destroy a context 
  *  dpy: display
@@ -1129,6 +1129,42 @@ VAStatus vaDestroyContext (
     VADisplay dpy,
     VAContextID context
 );
+
+//Multi-frame context
+typedef VAGenericID VAMFContextID;
+/**
+ * vaCreateMFContext - Create a multi-frame context
+ *  Multi-frame context allow to run tasks from different
+ *  contexts in single batch buffer for performance optimization.
+ *  Multi-frame context destroyd by vaDestroyContext
+ *  dpy: display
+ *  mf_context: created multi-frame context id upon return
+ */
+VAStatus vaCreateMFContext (
+    VADisplay dpy,
+    VAMFContextID *mf_context    /* out */
+);
+
+/**
+ * vaMFAddContext - Add context into multi-frame and cerate
+ *  association with multi-frame context.
+ *  After association is done, current context will not submit 
+ *  render targets during vaEndPicture, but during vaMFSubmit.
+ *  dpy: display
+ *  context: VAContextID to be added
+ *  mf_context: VAMFContextID where context is added
+ */
+VAStatus vaMFAddContext (VADisplay dpy, VAContextID context, VAMFContextID mfe_context)
+
+/**
+ * vaMFReleaseContext - Removes context from multi-frame and
+ *  association with multi-frame context.
+ *  After association removed vaEndPicture will submit tasks, but not vaMFSubmit.
+ *  dpy: display
+ *  context: VAContextID to be added
+ *  mf_context: VAMFContextID where context is added
+ */
+VAStatus vaMFReleaseContext (VADisplay dpy, VAContextID context, VAMFContextID mfe_context)
 
 /**
  * Buffers 
@@ -2500,6 +2536,24 @@ VAStatus vaRenderPicture (
 VAStatus vaEndPicture (
     VADisplay dpy,
     VAContextID context
+);
+
+/**
+ * Make the end of rendering for a pictures in contexts passed with submission. 
+ * The server should start processing all pending operations for contexts.
+ * All contexts passed to should be associated through vaMFAddContext
+ * and call sequence Begin/Render/End performed.
+ * This call is non-blocking. The client can start another 
+ * Begin/Render/End/vaMFSubmit sequence on a different render targets.
+ * dpy: display
+ * mf_context: Multi-Frame context
+ * contexts: list of contexts submitting their tasks for multi-frame operation. 
+ */
+VAStatus vaMFSubmit (
+    VADisplay dpy,
+    VAMFContextID mf_context,
+    VAContextID * contexts,
+    int num_contexts
 );
 
 /*

--- a/va/va_backend.h
+++ b/va/va_backend.h
@@ -133,6 +133,30 @@ struct VADriverVTable
 		VAContextID context
 	);
 
+	VAStatus (*vaCreateMFContext) (
+		VADriverContextP ctx,
+		VAMFContextID *mfe_context    /* out */
+	);
+
+	VAStatus (*vaMFAddContext) (
+		VADriverContextP ctx,
+		VAContextID context,
+		VAMFContextID mf_context
+	);
+
+	VAStatus (*vaMFReleaseContext) (
+		VADriverContextP ctx,
+		VAContextID context,
+		VAMFContextID mf_context
+	);
+
+	VAStatus (*vaMFSubmit) (
+		VADriverContextP ctx,
+		VAMFContextID mf_context,
+		VAContextID *contexts,
+		int num_contexts
+	);
+
 	VAStatus (*vaCreateBuffer) (
 		VADriverContextP ctx,
 		VAContextID context,		/* in */

--- a/va/va_trace.c
+++ b/va/va_trace.c
@@ -1496,7 +1496,7 @@ void va_TraceMFSubmit (
         va_TraceMsg(trace_ctx, "\t\tcontext[%d] = 0x%08x\n", i, contexts[i]);
 	}
 }
-*/
+
 static char * buffer_type_to_string(int type)
 {
     switch (type) {

--- a/va/va_trace.c
+++ b/va/va_trace.c
@@ -1438,6 +1438,65 @@ void va_TraceDestroyContext (
     UNLOCK_CONTEXT(pva_trace);
 }
 
+void va_TraceCreateMFContext (
+    VADisplay dpy,
+    VAMFContextID *mf_context    /* out */
+)
+{
+    DPY2TRACECTX(dpy);
+
+    TRACE_FUNCNAME(idx);
+    if (mf_context) {
+        va_TraceMsg(trace_ctx, "\tmf_context = 0x%08x\n", *mf_context);
+        trace_ctx->trace_context = *mf_context;
+    } else
+        trace_ctx->trace_context = VA_INVALID_ID;
+}
+
+void va_TraceMFAddContext (
+    VADisplay dpy,
+    VAContextID context,
+    VAMFContextID mf_context
+)
+{
+    DPY2TRACECTX(dpy);
+
+    TRACE_FUNCNAME(idx);
+    va_TraceMsg(trace_ctx, "\tmf_context = 0x%08x\n", mf_context);
+    va_TraceMsg(trace_ctx, "\tcontext = 0x%08x\n", context);
+}
+
+void va_TraceMFReleaseContext (
+    VADisplay dpy,
+    VAContextID context,
+    VAMFContextID mf_context
+)
+{
+    DPY2TRACECTX(dpy);
+
+    TRACE_FUNCNAME(idx);
+    va_TraceMsg(trace_ctx, "\tmf_context = 0x%08x\n", mf_context);
+    va_TraceMsg(trace_ctx, "\tcontext = 0x%08x\n", context);
+}
+
+void va_TraceMFSubmit (
+    VADisplay dpy,
+    VAMFContextID mf_context,
+    VAContextID *contexts,
+    int num_contexts
+)
+{
+    int i;
+
+    DPY2TRACECTX(dpy);
+
+    TRACE_FUNCNAME(idx);
+    va_TraceMsg(trace_ctx, "\tmf_context = 0x%08x\n", mf_context);
+
+    for(i = 0; i < num_contexts; i++)
+        va_TraceMsg(trace_ctx, "\t\tcontext[%d] = 0x%08x\n", i, contexts[i]);
+}
+
 static char * buffer_type_to_string(int type)
 {
     switch (type) {

--- a/va/va_trace.c
+++ b/va/va_trace.c
@@ -1443,8 +1443,6 @@ void va_TraceCreateMFContext (
     VAMFContextID *mf_context    /* out */
 )
 {
-    DPY2TRACECTX(dpy);
-
     TRACE_FUNCNAME(idx);
     if (mf_context) {
         va_TraceMsg(trace_ctx, "\tmf_context = 0x%08x\n", *mf_context);
@@ -1459,10 +1457,11 @@ void va_TraceMFAddContext (
     VAMFContextID mf_context
 )
 {
-    DPY2TRACECTX(dpy);
+    DPY2TRACECTX(dpy, mf_context, VA_INVALID_ID);
 
     TRACE_FUNCNAME(idx);
     va_TraceMsg(trace_ctx, "\tmf_context = 0x%08x\n", mf_context);
+    DPY2TRACECTX(dpy, context, VA_INVALID_ID);
     va_TraceMsg(trace_ctx, "\tcontext = 0x%08x\n", context);
 }
 
@@ -1472,10 +1471,11 @@ void va_TraceMFReleaseContext (
     VAMFContextID mf_context
 )
 {
-    DPY2TRACECTX(dpy);
+    DPY2TRACECTX(dpy, mf_context, VA_INVALID_ID);
 
     TRACE_FUNCNAME(idx);
     va_TraceMsg(trace_ctx, "\tmf_context = 0x%08x\n", mf_context);
+    DPY2TRACECTX(dpy, context, VA_INVALID_ID);
     va_TraceMsg(trace_ctx, "\tcontext = 0x%08x\n", context);
 }
 
@@ -1488,13 +1488,15 @@ void va_TraceMFSubmit (
 {
     int i;
 
-    DPY2TRACECTX(dpy);
+    DPY2TRACECTX(dpy, mf_context, VA_INVALID_ID);
 
     TRACE_FUNCNAME(idx);
     va_TraceMsg(trace_ctx, "\tmf_context = 0x%08x\n", mf_context);
 
-    for(i = 0; i < num_contexts; i++)
+    for(i = 0; i < num_contexts; i++){
+        DPY2TRACECTX(dpy, context[i], VA_INVALID_ID);
         va_TraceMsg(trace_ctx, "\t\tcontext[%d] = 0x%08x\n", i, contexts[i]);
+	}
 }
 
 static char * buffer_type_to_string(int type)

--- a/va/va_trace.c
+++ b/va/va_trace.c
@@ -1437,12 +1437,13 @@ void va_TraceDestroyContext (
 
     UNLOCK_CONTEXT(pva_trace);
 }
-
+/*
 void va_TraceCreateMFContext (
     VADisplay dpy,
     VAMFContextID *mf_context    /* out */
 )
 {
+    DPY2TRACECTX(dpy, VA_INVALID_ID, VA_INVALID_ID);
     TRACE_FUNCNAME(idx);
     if (mf_context) {
         va_TraceMsg(trace_ctx, "\tmf_context = 0x%08x\n", *mf_context);
@@ -1461,7 +1462,7 @@ void va_TraceMFAddContext (
 
     TRACE_FUNCNAME(idx);
     va_TraceMsg(trace_ctx, "\tmf_context = 0x%08x\n", mf_context);
-    DPY2TRACECTX(dpy, context, VA_INVALID_ID);
+    trace_ctx->trace_context
     va_TraceMsg(trace_ctx, "\tcontext = 0x%08x\n", context);
 }
 
@@ -1498,7 +1499,7 @@ void va_TraceMFSubmit (
         va_TraceMsg(trace_ctx, "\t\tcontext[%d] = 0x%08x\n", i, contexts[i]);
 	}
 }
-
+*/
 static char * buffer_type_to_string(int type)
 {
     switch (type) {

--- a/va/va_trace.c
+++ b/va/va_trace.c
@@ -1437,7 +1437,7 @@ void va_TraceDestroyContext (
 
     UNLOCK_CONTEXT(pva_trace);
 }
-/*
+
 void va_TraceCreateMFContext (
     VADisplay dpy,
     VAMFContextID *mf_context    /* out */
@@ -1462,7 +1462,6 @@ void va_TraceMFAddContext (
 
     TRACE_FUNCNAME(idx);
     va_TraceMsg(trace_ctx, "\tmf_context = 0x%08x\n", mf_context);
-    trace_ctx->trace_context
     va_TraceMsg(trace_ctx, "\tcontext = 0x%08x\n", context);
 }
 
@@ -1476,7 +1475,6 @@ void va_TraceMFReleaseContext (
 
     TRACE_FUNCNAME(idx);
     va_TraceMsg(trace_ctx, "\tmf_context = 0x%08x\n", mf_context);
-    DPY2TRACECTX(dpy, context, VA_INVALID_ID);
     va_TraceMsg(trace_ctx, "\tcontext = 0x%08x\n", context);
 }
 
@@ -1495,7 +1493,6 @@ void va_TraceMFSubmit (
     va_TraceMsg(trace_ctx, "\tmf_context = 0x%08x\n", mf_context);
 
     for(i = 0; i < num_contexts; i++){
-        DPY2TRACECTX(dpy, context[i], VA_INVALID_ID);
         va_TraceMsg(trace_ctx, "\t\tcontext[%d] = 0x%08x\n", i, contexts[i]);
 	}
 }

--- a/va/va_trace.h
+++ b/va/va_trace.h
@@ -121,6 +121,34 @@ void va_TraceDestroyContext (
 );
 
 DLL_HIDDEN
+void va_TraceCreateMFContext (
+    VADisplay dpy,
+    VAContextID *mf_context	/* out */
+);
+
+DLL_HIDDEN
+void va_TraceMFAddContext (
+    VADisplay dpy,
+    VAContextID context,
+    VAMFContextID mf_context
+);
+
+DLL_HIDDEN
+void va_TraceMFReleaseContext (
+    VADisplay dpy,
+    VAContextID context,
+    VAMFContextID mf_context
+);
+
+DLL_HIDDEN
+void va_TraceMFSubmit (
+    VADisplay dpy,
+    VAMFContextID mf_context,
+    VAContextID *contexts,
+    int num_contexts
+);
+
+DLL_HIDDEN
 void va_TraceCreateBuffer (
     VADisplay dpy,
     VAContextID context,	/* in */


### PR DESCRIPTION
New VAAPI definition for multi-frame processing applicable for Encode, FEI Encode/ENC/Pre-ENC, and VPP in future.
Multi-frame processing is an optimization, that allows to run several tasks inside one batch buffer to better reuse EU and fixed function such as media sampler, as well as decrease CPU overhead for batch buffer submission.

VAStatus vaCreateMFContext (VADisplay dpy, VAMFContextID *mf_context);

Description:
Entry point to create new Multi-Frame context interface encapsulating common for all streams memory objects and structures required for single batch buffer submission from several VAContextID's.
Allocation: This call only creates an instance, doesn't allocate any additional memory.
Support identification: Application can identify multi-frame feature support by ability to create multi-frame context. If driver supports multi-frame - call successful, mf_context != NULL and VAStatus = VA_STATUS_SUCCESS, otherwise if multi-frame processing not supported driver returns VA_STATUS_ERROR_UNIMPLEMENTED and mf_context = NULL.

Arguments:
VADisplay dpy - display adapter.
VAMFContextID *out_context - MF context encapsulating all associated encoder context for multi-frame submission.

Return value:
VA_STATUS_SUCCESS - operation successful.
VA_STATUS_ERROR_UNIMPLEMENTED - no support for multi-frame.

VAStatus vaMFAddContext (VADisplay dpy, VAContextID context, VAMFContextID mfe_context);

Description:
Provide ability to associate each encoder context used for submission and common MF context.
Query - try to add context to understand if it is supported.
Allocation: this call allocates and/or reallocates all memory objects common for all streams associated with particular MF context.
All memory required for each encoder context(pixel buffers, per stream buffers such as PAKObj, motion vector buffers, predictor buffers, etc.) allocated during standard vaCreateContext call for each stream.
Runtime dependency - if current implementation doesn't allow to run different entry points/profile, first context added will set entry point/profile for whole MF Context, all other entry points and profiles will be rejected to be added.

Arguments:
VADisplay dpy - display adapter.
VAContextID context - context being associated with Multi-Frame context.
VAMFContextID mf_context - multi-frame context used to associate other contexts and for multi-frame submission.

Return value:
VA_STATUS_SUCCESS - operation successful, context was added.
VA_STATUS_ERROR_OPERATION_FAILED - something unexpected happened.
VA_STATUS_ERROR_INVALID_CONTEXT - ContextID is invalid - entry point and/or profile contradicts with previously added.
VA_STATUS_ERROR_UNSUPPORTED_ENTRYPOINT - particular VAContextID created with VAConfigID associated with VAEntrypoint that is not supported, as an example VAEntrypointVLD not supported(as decoder doesn't make sense for MF operation), VAEntrypointVideoProc and/or VAEntrypointFEI not supported at a moment, etc.
VA_STATUS_ERROR_UNSUPPORTED_PROFILE - Current context with Particular VAEntrypoint is supported, but VAProfile is not supported(so for example H264 encode or FEI is supported, but H265/Mpeg2 not supported at a moment)

Limitations:
Number of encoder contexts per MF context - should not be limited.
Base on implementation - can limit: different VAEntrypoint/VAProfile(codec) inside one context


VAStatus vaMFReleaseContext (VADisplay dpy, VAContextID context, VAMFContextID mf_context);
Description:
Provides ability to remove association between MF context and particular encode context. This is not necessary, can be removed, as the same can be done through vaDestroyContext, however such support brings hidden from App, unclear logic in driver.

Arguments:
VADisplay dpy - display adapter.
VAContextID context - encoder context being removed from MFE context.
VAMFEContextID mfe_context - MFE context used to associate encode context and for submission.

Return value:
VA_STATUS_SUCCESS - operation successful, context was removed.
VA_STATUS_ERROR_OPERATION_FAILED - something unexpected happened.


VAStatus vaMFSubmit (VADisplay dpy, VAMFContextID mf_context, VAContextID *contexts, int num_contexts);

Description:
Provides ability to submit frames from multiple contexts streams for execution.

Arguments:
VADisplay dpy - display adapter.
VAMFContextID mf_context - MF context used for submission.
VAContextID *contexts - contexts with frames ready for submission.
int num_contexts - number of context in contexts.

Return value:
VA_STATUS_SUCCESS - operation successful, context was removed.
VA_STATUS_ERROR_INVALID_CONTEXT - mf_context or one of contexts are invalid due to mf_context not created or one of contexts not assotiated with mf_context through vaAddContext.
VA_STATUS_ERROR_INVALID_PARAMETER - one of context has not submitted it's frame through vaBeginPicture vaRenderPicture vaEndPicture call sequence.

Schematic code flow examples:
Initialization:

VADisplay dpy;
VAMFContextID mfe_context;
VAContextID contexts[N];
....
//initialize display, etc.
...
vaCreateMFContext(dpy, &mf_context);
.....
for N streams
{
    vaCreateConfig(dpy,...., &stream_config)            
    vaCreateContext(dpy, stream_config, ...., &context[i])
    vaAddContext(dpy, context[i], mf_context)    // Add this context into the MF context
}

Runtime:

VAContextID fContexts[M]; //frame contexts - to submit, M - max number of frames to submit, number of overall contexts associated with MF can be bigger than maximum number of frames to submit
....
// prepare streams ready to submit frames, fill contexts vector.
....
for M frames        // take frames ready for submission from differen streams, this can happen not 
{
    vaBeginPicture(dpy, fContexts[i], in_surf)
    vaRenderPicture(dpy, fContexts[i], buffers, buffer_count)
    vaEndPicture(dpy, fContexts[i])             // Delay real submission untill vaMFSubmit()
}
vaMFSubmit(dpy, mf_context, contexts, M)  // Submit through MF context

Destruction:

for each stream 
{
    vaReleaseContext(dpy, context, mf_context);    // remove context 
    vaDestroyContext(dpy, context);
}
vaDestroyContext(mf_context);